### PR TITLE
support 0.5.12+ import callback format

### DIFF
--- a/src/Language/Solidity/Compiler.js
+++ b/src/Language/Solidity/Compiler.js
@@ -114,7 +114,7 @@ exports._compile = function (solc, input, readCallback) {
           const isVersionV5_12_plus = version.startsWith("0.5.1") && !version.startsWith("0.5.1+") && !version.startsWith("0.5.1-") && !version.startsWith("0.5.10") && !version.startsWith("0.5.11");
           const isNewCallbackFormat = !version.startsWith("0.4") || isVersionV5_12_plus;
           if (isNewCallbackFormat) {
-            return solc.compile(i, { import: cb });
+            return solc.compile(i, { "import": cb });
           } else {
             return solc.compile(i, cb);
           }

--- a/src/Language/Solidity/Compiler.js
+++ b/src/Language/Solidity/Compiler.js
@@ -105,7 +105,19 @@ exports._compile = function (solc, input, readCallback) {
           // if we got here we're probably using version 0.5.x or above AND they actually went through on their promise to remove the deprecated
           // compileStandardWrapper (they said they'd get rid of it after 0.5.3, but 0.5.11 (latest as of this writing) still has it).
           // odds are we can just call solc.compile()!
-          return solc.compile(i, cb);
+
+          // unless we're running 0.5.12+, which made the `callback` argument an object. in which case, we need to
+          // a. instead of passing cb directly to compile, we have to give an object that looks like `{ import: cb }`
+          // b. instead of returning the string output of cb straight to solc, we have to return it an object `{ contents: "str" }`
+          // shoot me in the face
+          // todo: replace all this string checking with a proper version parser/comparison
+          const isVersionV5_12_plus = version.startsWith("0.5.1") && !version.startsWith("0.5.1+") && !version.startsWith("0.5.1-") && !version.startsWith("0.5.10") && !version.startsWith("0.5.11");
+          const isNewCallbackFormat = !version.startsWith("0.4") || isVersionV5_12_plus;
+          if (isNewCallbackFormat) {
+            return solc.compile(i, { import: cb });
+          } else {
+            return solc.compile(i, cb);
+          }
         }
       }
     };


### PR DESCRIPTION
Solc 0.5.12 introduced a new way to pass the import callback, as it now supports multiple types of callbacks from the compiler. Solc 0.6 made using this new way mandatory.

We check if we're running a support Solc 0.5.12 or greater. If we are, use the new callback object, otherwise, use a simple function.