### PR TITLE
callback fallback

### DIFF
--- a/src/Language/Solidity/Compiler.js
+++ b/src/Language/Solidity/Compiler.js
@@ -130,7 +130,14 @@ exports._compile = function (solc, input, readCallback) {
 
           if (isNewCallbackFormat) {
             try {
-            return solc.compile(i, { "import": cb });
+              return solc.compile(i, { "import": cb });
+            } catch (e) {
+              if (isCallbackError(e)) {
+                return solc.compile(i, cb);
+              } else {
+                throw e;
+              }
+            }
           } else {
             try {
               return solc.compile(i, cb);


### PR DESCRIPTION
fallback to using a newer style callback for older solc blobs, because apparently they reuploaded older versions of solc-js with newer APIs...

seriously, who does that???